### PR TITLE
GDMC-HTTP v0.6 compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To download one of the following scripts, click on the link, then right-click an
 - Blinkenlights
 - Nils Gawlik
 - Claus Aranha
+- Niels NTG Poldervaart
 
 with contributions from:
 - Mayank Jain

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDPC 5.0 (Manicule)
 
-GDPC (Generative Design Python Client) is a framework for use in conjunction with the [Minecraft HTTP Interface Mod](https://github.com/Niels-NTG/gdmc_http_interface) (version 0.5.X), built for the [GDMC competition](https://gendesignmc.engineering.nyu.edu).
+GDPC (Generative Design Python Client) is a framework for use in conjunction with the [Minecraft HTTP Interface Mod](https://github.com/Niels-NTG/gdmc_http_interface) (version 0.6.X), built for the [GDMC competition](https://gendesignmc.engineering.nyu.edu).
 
 You need to be playing in a Minecraft world with the mod installed to use the framework.
 

--- a/gdpc/direct_interface.py
+++ b/gdpc/direct_interface.py
@@ -72,7 +72,7 @@ def placeBlock(x, y, z, blockStr, doBlockUpdates=True, customFlags=None, dimensi
     }
     headers = {'Accept': 'application/json'} if asJsonResponse else {}
     try:
-        response = requests.put(url, data=blockStr, params=parameters, headers=headers)
+        response = requests.put(url, data=bytes(blockStr, "utf-8"), params=parameters, headers=headers)
     except RequestConnectionError:
         return "0"
     if asJsonResponse:

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -93,11 +93,11 @@ class Interface():
             if not checkOutOfBounds(x, y, z) and not globalDecay[dx][dy][dz]:
                 block = globalWorldSlice.getBlockAt(x, y, z)
                 if block == 'minecraft:void_air':
-                    block = di.getBlock(x, y, z)
+                    block = di.getBlock(x, y, z).get('id')
                 self.cache[(x, y, z)] = block
                 return block
 
-        response = di.getBlock(x, y, z)
+        response = di.getBlock(x, y, z).get('id')
         if self.caching:
             self.cache[(x, y, z)] = response
 

--- a/gdpc/interface_toolbox.py
+++ b/gdpc/interface_toolbox.py
@@ -47,12 +47,10 @@ def placeLectern(x, y, z, bookData, facing=None, interface=gi):
     """Place a lectern with a book in the world."""
     if facing is None:
         facing = choice(getOptimalDirection(x, y, z))
-    interface.placeBlock(x, y, z, f"lectern[facing={facing}, has_book=true]")
-    command = (f'data merge block {x} {y} {z} '
+    response = interface.placeBlock(x, y, z, f"lectern[facing={facing}, has_book=true]" + \
                f'{{Book: {{id: "minecraft:written_book", '
                f'Count: 1b, tag: {bookData}'
                '}, Page: 0}')
-    response = runCommand(command)
     if not response.isnumeric():
         print(f"{lookup.TCOLORS['orange']}Warning: Server returned error "
               f"upon placing book in lectern:\n\t{lookup.TCOLORS['CLR']}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,7 +110,7 @@ def testSynchronisation():
         for _z in range(z - 1, z + 2):
             for i in range(0, 128):
                 bws = ws.getBlockAt(_x, i, _z)
-                bdi = direct_interface.getBlock(_x, i, _z)
+                bdi = direct_interface.getBlock(_x, i, _z).get('id')
                 if (bws != bdi and bws != 'minecraft:void_air'):
                     print("{}: ws: {}, di: {}".format((_x, i, _z), bws, bdi))
                     error = True


### PR DESCRIPTION
Minor changes to ensure compatibility with [GDMC-HTTP v0.6.0](https://github.com/Niels-NTG/gdmc_http_interface/releases/tag/v0.6.0). This release makes it possible to get multiple blocks within an area using the `GET /blocks` endpoint.

Most important changes is that the response format for getting blocks has changed to include a block's position, since you can now request multiple blocks in a single request and have to know which one is which.

Also support for block entity data has been added to the `PUT /blocks endpoint`, removing the need to use the data merge command to do things such as populate inventory blocks with items or write books.

I've also added parameters in the direct interface to make #38 possible.