### PR TITLE
Set valid Accept header type for plain text

### DIFF
--- a/gdpc/direct_interface.py
+++ b/gdpc/direct_interface.py
@@ -134,7 +134,7 @@ def getChunks(x, z, dx, dz, dimension=None, rtype='text'):
         'dz': dz,
         'dimension': dimension,
     }
-    acceptType = 'application/octet-stream' if rtype == 'bytes' else 'text/raw'
+    acceptType = 'application/octet-stream' if rtype == 'bytes' else 'text/plain'
     response = requests.get(url, params=parameters, headers={"Accept": acceptType})
     if response.status_code >= 400:
         print(f"Error: {response.text}")


### PR DESCRIPTION
A very minor change to ensure compatibility with [GDMC-HTTP v0.7](https://github.com/Niels-NTG/gdmc_http_interface/releases/tag/v0.7.0). Since this version, `GET /chunks` returns binary (`"Accept": "application/octec-stream"`) by default instead of plain text. This isn't a problem if it weren't for that `"text/raw"` being a type that the API does not recognize. Nor should it, since `"text/plain"` is much more conventional.