### PR TITLE
Replace pyGLM vector parameters with VecLike ABCs

### DIFF
--- a/examples/Start_Here.py
+++ b/examples/Start_Here.py
@@ -39,8 +39,6 @@ import logging
 from termcolor import colored
 from random import randint
 
-from glm import ivec3
-
 from gdpc import Block, Editor
 from gdpc import geometry as geometry
 from gdpc import minecraft_tools as minecraft_tools
@@ -104,24 +102,24 @@ def buildPerimeter():
     for x in range(STARTX, LASTX + 1):
         # the northern wall
         y = heights[(x - STARTX, 0)]
-        geometry.placeCuboid(ED, ivec3(x, y - 2, STARTZ), ivec3(x, y, STARTZ), Block("granite"))
-        geometry.placeCuboid(ED, ivec3(x, y + 1, STARTZ), ivec3( x, y + 4, STARTZ), Block("granite_wall"))
+        geometry.placeCuboid(ED, (x, y - 2, STARTZ), (x, y, STARTZ), Block("granite"))
+        geometry.placeCuboid(ED, (x, y + 1, STARTZ), (x, y + 4, STARTZ), Block("granite_wall"))
         # the southern wall
         y = heights[(x - STARTX, LASTZ - STARTZ)]
-        geometry.placeCuboid(ED, ivec3(x, y - 2, LASTZ), ivec3( x, y, LASTZ), Block("red_sandstone"))
-        geometry.placeCuboid(ED, ivec3(x, y + 1, LASTZ), ivec3( x, y + 4, LASTZ), Block("red_sandstone_wall"))
+        geometry.placeCuboid(ED, (x, y - 2, LASTZ), (x, y, LASTZ), Block("red_sandstone"))
+        geometry.placeCuboid(ED, (x, y + 1, LASTZ), (x, y + 4, LASTZ), Block("red_sandstone_wall"))
 
     print("Building north-south walls...")
     # building the north-south walls
     for z in range(STARTZ, LASTZ + 1):
         # the western wall
         y = heights[(0, z - STARTZ)]
-        geometry.placeCuboid(ED, ivec3(STARTX, y - 2, z), ivec3( STARTX, y, z), Block("sandstone"))
-        geometry.placeCuboid(ED, ivec3(STARTX, y + 1, z), ivec3( STARTX, y + 4, z), Block("sandstone_wall"))
+        geometry.placeCuboid(ED, (STARTX, y - 2, z), (STARTX, y, z), Block("sandstone"))
+        geometry.placeCuboid(ED, (STARTX, y + 1, z), (STARTX, y + 4, z), Block("sandstone_wall"))
         # the eastern wall
         y = heights[(LASTX - STARTX, z - STARTZ)]
-        geometry.placeCuboid(ED, ivec3(LASTX, y - 2, z), ivec3( LASTX, y, z), Block("prismarine"))
-        geometry.placeCuboid(ED, ivec3(LASTX, y + 1, z), ivec3( LASTX, y + 4, z), Block("prismarine_wall"))
+        geometry.placeCuboid(ED, (LASTX, y - 2, z), (LASTX, y, z), Block("prismarine"))
+        geometry.placeCuboid(ED, (LASTX, y + 1, z), (LASTX, y + 4, z), Block("prismarine_wall"))
 
 
 def buildRoads():
@@ -148,17 +146,17 @@ def buildRoads():
 
     print("Building east-west road...")
     # building the east-west road
-    geometry.placeCuboid(ED, ivec3(xaxis - 2, y, STARTZ), ivec3(xaxis - 2, y, LASTZ), Block("end_stone_bricks"))
-    geometry.placeCuboid(ED, ivec3(xaxis - 1, y, STARTZ), ivec3(xaxis + 1, y, LASTZ), Block("gold_block"))
-    geometry.placeCuboid(ED, ivec3(xaxis + 2, y, STARTZ), ivec3(xaxis + 2, y, LASTZ), Block("end_stone_bricks"))
-    geometry.placeCuboid(ED, ivec3(xaxis - 1, y + 1, STARTZ), ivec3(xaxis + 1, y + 3, LASTZ), Block("air"))
+    geometry.placeCuboid(ED, (xaxis - 2, y, STARTZ), (xaxis - 2, y, LASTZ), Block("end_stone_bricks"))
+    geometry.placeCuboid(ED, (xaxis - 1, y, STARTZ), (xaxis + 1, y, LASTZ), Block("gold_block"))
+    geometry.placeCuboid(ED, (xaxis + 2, y, STARTZ), (xaxis + 2, y, LASTZ), Block("end_stone_bricks"))
+    geometry.placeCuboid(ED, (xaxis - 1, y + 1, STARTZ), (xaxis + 1, y + 3, LASTZ), Block("air"))
 
     print("Building north-south road...")
     # building the north-south road
-    geometry.placeCuboid(ED, ivec3(STARTX, y, zaxis - 2), ivec3(LASTX, y, zaxis - 2), Block("end_stone_bricks"))
-    geometry.placeCuboid(ED, ivec3(STARTX, y, zaxis - 1), ivec3(LASTX, y, zaxis + 1), Block("gold_block"))
-    geometry.placeCuboid(ED, ivec3(STARTX, y, zaxis + 2), ivec3(LASTX, y, zaxis + 2), Block("end_stone_bricks"))
-    geometry.placeCuboid(ED, ivec3(STARTX, y + 1, zaxis - 1), ivec3(LASTX, y + 3, zaxis + 1), Block("air"))
+    geometry.placeCuboid(ED, (STARTX, y, zaxis - 2), (LASTX, y, zaxis - 2), Block("end_stone_bricks"))
+    geometry.placeCuboid(ED, (STARTX, y, zaxis - 1), (LASTX, y, zaxis + 1), Block("gold_block"))
+    geometry.placeCuboid(ED, (STARTX, y, zaxis + 2), (LASTX, y, zaxis + 2), Block("end_stone_bricks"))
+    geometry.placeCuboid(ED, (STARTX, y + 1, zaxis - 1), (LASTX, y + 3, zaxis + 1), Block("air"))
 
 
 def buildCity():
@@ -168,16 +166,16 @@ def buildCity():
 
     print("Building city platform...")
     # Building a platform and clearing a dome for the city to sit in
-    geometry.placeCylinder(ED, ivec3(xaxis, y,      zaxis), 39, 1, Block("end_stone_bricks"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y,      zaxis), 37, 1, Block("gold_block"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  1, zaxis), 37, 3, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  4, zaxis), 35, 2, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  6, zaxis), 33, 1, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  7, zaxis), 32, 1, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  8, zaxis), 27, 1, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y +  9, zaxis), 21, 1, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y + 10, zaxis), 13, 1, Block("air"))
-    geometry.placeCylinder(ED, ivec3(xaxis, y + 11, zaxis),  3, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y,      zaxis), 39, 1, Block("end_stone_bricks"))
+    geometry.placeCylinder(ED, (xaxis, y,      zaxis), 37, 1, Block("gold_block"))
+    geometry.placeCylinder(ED, (xaxis, y +  1, zaxis), 37, 3, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y +  4, zaxis), 35, 2, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y +  6, zaxis), 33, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y +  7, zaxis), 32, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y +  8, zaxis), 27, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y +  9, zaxis), 21, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y + 10, zaxis), 13, 1, Block("air"))
+    geometry.placeCylinder(ED, (xaxis, y + 11, zaxis),  3, 1, Block("air"))
 
     for _ in range(50):
         buildTower(randint(xaxis - 20, xaxis + 20),
@@ -185,9 +183,9 @@ def buildCity():
 
     # Place a book on a Lectern
     # See the wiki for book formatting codes
-    ED.placeBlock(ivec3(xaxis, y, zaxis), Block("emerald_block"))
+    ED.placeBlock((xaxis, y, zaxis), Block("emerald_block"))
     bookData = minecraft_tools.bookData("This book has a page!")
-    editor_tools.placeLectern(ED, ivec3(xaxis, y + 1, zaxis), bookData=bookData)
+    editor_tools.placeLectern(ED, (xaxis, y + 1, zaxis), bookData=bookData)
 
 
 def buildTower(x, z):
@@ -198,48 +196,48 @@ def buildTower(x, z):
     print(f"Building tower at {x}, {z}...")
     # if the blocks to the north, south, east and west aren't all gold
     if not (
-            ED.getBlock(ivec3(x - radius, y, z)).id == "minecraft:gold_block"
-        and ED.getBlock(ivec3(x + radius, y, z)).id == "minecraft:gold_block"
-        and ED.getBlock(ivec3(x, y, z - radius)).id == "minecraft:gold_block"
-        and ED.getBlock(ivec3(x, y, z + radius)).id == "minecraft:gold_block"
+            ED.getBlock((x - radius, y, z)).id == "minecraft:gold_block"
+        and ED.getBlock((x + radius, y, z)).id == "minecraft:gold_block"
+        and ED.getBlock((x, y, z - radius)).id == "minecraft:gold_block"
+        and ED.getBlock((x, y, z + radius)).id == "minecraft:gold_block"
     ):
         return  # return without building anything
 
     # lay the foundation
-    geometry.placeCylinder(ED, ivec3(x, y, z), diameter, 1, Block("emerald_block"))
+    geometry.placeCylinder(ED, (x, y, z), diameter, 1, Block("emerald_block"))
 
     # build ground floor
-    geometry.placeCylinder(ED, ivec3(x, y + 1, z), diameter, 3, Block("lime_concrete"), tube=True)
+    geometry.placeCylinder(ED, (x, y + 1, z), diameter, 3, Block("lime_concrete"), tube=True)
 
     # extend height
     height = randint(5, 20)
-    geometry.placeCylinder(ED, ivec3(x, y + 4, z), diameter, height, Block("lime_concrete"), tube=True)
+    geometry.placeCylinder(ED, (x, y + 4, z), diameter, height, Block("lime_concrete"), tube=True)
     height += 4
 
     # build roof
-    geometry.placeCylinder(ED, ivec3(x, y + height, z), diameter, 1, Block("emerald_block"))
-    geometry.placeCylinder(ED, ivec3(x, y + height + 1, z), diameter-2, 2, Block("emerald_block"))
-    geometry.placeCuboid(ED, ivec3(x, y + height, z), ivec3(x, y + height + 2, z), Block("lime_stained_glass"))
-    ED.placeBlock(ivec3(x, y + 1, z), Block("beacon"))
+    geometry.placeCylinder(ED, (x, y + height, z), diameter, 1, Block("emerald_block"))
+    geometry.placeCylinder(ED, (x, y + height + 1, z), diameter-2, 2, Block("emerald_block"))
+    geometry.placeCuboid(ED, (x, y + height, z), (x, y + height + 2, z), Block("lime_stained_glass"))
+    ED.placeBlock((x, y + 1, z), Block("beacon"))
 
     # trim sides and add windows and doors
     # NOTE: When placing doors, you only need to place the bottom block.
     # the upper block defines the direction
-    geometry.placeCuboid(ED, ivec3(x + radius, y + 1, z), ivec3( x + radius, y + height + 2, z), Block("air"))
-    geometry.placeCuboid(ED, ivec3(x + radius - 1, y + 1, z), ivec3(x + radius - 1, y + height + 2, z), Block("lime_stained_glass"))
-    ED.placeBlock(ivec3(x + radius - 1, y + 1, z), Block("warped_door", {"facing": "west"}))
+    geometry.placeCuboid(ED, (x + radius, y + 1, z), (x + radius, y + height + 2, z), Block("air"))
+    geometry.placeCuboid(ED, (x + radius - 1, y + 1, z), (x + radius - 1, y + height + 2, z), Block("lime_stained_glass"))
+    ED.placeBlock((x + radius - 1, y + 1, z), Block("warped_door", {"facing": "west"}))
 
-    geometry.placeCuboid(ED, ivec3(x - radius, y + 1, z), ivec3( x - radius, y + height + 2, z), Block("air"))
-    geometry.placeCuboid(ED, ivec3(x - radius + 1, y + 1, z), ivec3(x - radius + 1, y + height + 2, z), Block("lime_stained_glass"))
-    ED.placeBlock(ivec3(x - radius + 1, y + 1, z), Block("warped_door", {"facing": "east"}))
+    geometry.placeCuboid(ED, (x - radius, y + 1, z), (x - radius, y + height + 2, z), Block("air"))
+    geometry.placeCuboid(ED, (x - radius + 1, y + 1, z), (x - radius + 1, y + height + 2, z), Block("lime_stained_glass"))
+    ED.placeBlock((x - radius + 1, y + 1, z), Block("warped_door", {"facing": "east"}))
 
-    geometry.placeCuboid(ED, ivec3(x, y + 1, z + radius), ivec3( x, y + height + 2, z + radius), Block("air"))
-    geometry.placeCuboid(ED, ivec3(x, y + 1, z + radius - 1), ivec3(x, y + height + 2, z + radius - 1), Block("lime_stained_glass"))
-    ED.placeBlock(ivec3(x, y + 1, z + radius - 1), Block("warped_door", {"facing": "north"}))
+    geometry.placeCuboid(ED, (x, y + 1, z + radius), (x, y + height + 2, z + radius), Block("air"))
+    geometry.placeCuboid(ED, (x, y + 1, z + radius - 1), (x, y + height + 2, z + radius - 1), Block("lime_stained_glass"))
+    ED.placeBlock((x, y + 1, z + radius - 1), Block("warped_door", {"facing": "north"}))
 
-    geometry.placeCuboid(ED, ivec3(x, y + 1, z - radius), ivec3( x, y + height + 2, z - radius), Block("air"))
-    geometry.placeCuboid(ED, ivec3(x, y + 1, z - radius + 1), ivec3(x, y + height + 2, z - radius + 1), Block("lime_stained_glass"))
-    ED.placeBlock(ivec3(x, y + 1, z - radius + 1), Block("warped_door", {"facing": "south"}))
+    geometry.placeCuboid(ED, (x, y + 1, z - radius), (x, y + height + 2, z - radius), Block("air"))
+    geometry.placeCuboid(ED, (x, y + 1, z - radius + 1), (x, y + height + 2, z - radius + 1), Block("lime_stained_glass"))
+    ED.placeBlock((x, y + 1, z - radius + 1), Block("warped_door", {"facing": "south"}))
 
 
 # === STRUCTURE #4

--- a/examples/visualizeMap.py
+++ b/examples/visualizeMap.py
@@ -2,7 +2,6 @@
 
 """### Displays a map of the build area."""
 
-from glm import ivec3
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -43,7 +42,7 @@ if __name__ == '__main__':
             # calculate absolute coordinates
             y = int(heightmap[(x - x1, z - z1)]) - dy
 
-            block = worldSlice.getBlockGlobal(ivec3(x,y,z))
+            block = worldSlice.getBlockGlobal((x,y,z))
             if block.id in lookup.MAP_TRANSPARENT:
                 # transparent blocks are ignored
                 continue

--- a/gdpc/block.py
+++ b/gdpc/block.py
@@ -9,6 +9,7 @@ import random
 from glm import bvec3
 from nbt import nbt
 
+from .vector_tools import Vec3bLike
 from .nbt_tools import nbtToPythonObject, pythonObjectToSnbt
 from .block_state_tools import transformAxis, transformFacing, transformRotation
 
@@ -55,7 +56,7 @@ class Block:
         return result
 
 
-    def transform(self, rotation: int = 0, flip: bvec3 = bvec3()):
+    def transform(self, rotation: int = 0, flip: Vec3bLike = bvec3()):
         """Transforms this block.\n
         Flips first, rotates second."""
         axisState     = self.states.get("axis")
@@ -66,7 +67,7 @@ class Block:
         if rotationState is not None: self.states["rotation"] = transformRotation(rotationState, rotation, flip)
 
 
-    def transformed(self, rotation: int = 0, flip: bvec3 = bvec3()):
+    def transformed(self, rotation: int = 0, flip: Vec3bLike = bvec3()):
         """Returns a transformed copy of this block.\n
         Flips first, rotates second."""
         block = deepcopy(self)

--- a/gdpc/block_state_tools.py
+++ b/gdpc/block_state_tools.py
@@ -3,6 +3,8 @@
 
 from glm import ivec3, bvec3
 
+from .vector_tools import Vec3iLike, Vec3bLike
+
 
 # ==================================================================================================
 # Listings
@@ -67,12 +69,12 @@ __VECTOR_TO_AXIS = {
     (0,1,0): "y",
     (0,0,1): "z",
 }
-def vectorToAxis(vec: ivec3):
+def vectorToAxis(vec: Vec3iLike):
     """Returns the "axis" block state string corresponding to the direction vector [vec]"""
     v = (
-        vec.x != 0,
-        vec.y != 0,
-        vec.z != 0,
+        vec[0] != 0,
+        vec[1] != 0,
+        vec[2] != 0,
     )
     try:
         return __VECTOR_TO_AXIS[v]
@@ -102,7 +104,7 @@ __VECTOR_TO_FACING = {
     (-1, 0, 0): "west",
     ( 1, 0, 0): "east",
 }
-def vectorToFacing(vec: ivec3):
+def vectorToFacing(vec: Vec3iLike):
     """Returns the "facing" block state string corresponding to the direction vector [vec]"""
     v = (
         -1 if vec[0] < 0 else 1 if vec[0] > 0 else 0,
@@ -177,21 +179,21 @@ def rotateFacing(facing: str, rotation: int):
         return facing # up, down
 
 
-def flipFacing(facing: str, flip: bvec3):
+def flipFacing(facing: str, flip: Vec3bLike):
     """Returns the flipped "facing" block state string"""
-    if flip.x:
+    if flip[0]:
         if facing == "east":  return "west"
         if facing == "west":  return "east"
-    if flip.y:
+    if flip[1]:
         if facing == "down":  return "up"
         if facing == "up":    return "down"
-    if flip.z:
+    if flip[2]:
         if facing == "north": return "south"
         if facing == "south": return "north"
     return facing
 
 
-def transformFacing(facing: str, rotation: int = 0, flip: bvec3 = bvec3()):
+def transformFacing(facing: str, rotation: int = 0, flip: Vec3bLike = bvec3()):
     """Returns the transformed "facing" block state string.\n
     Flips first, rotates second."""
     return rotateFacing(flipFacing(facing, flip), rotation)
@@ -222,17 +224,17 @@ def rotateRotation(blockStateRotation: str, rotation: int):
     return str((int(blockStateRotation) + 4*rotation) % 16)
 
 
-def flipRotation(rotation: str, flip: bvec3):
+def flipRotation(rotation: str, flip: Vec3bLike):
     """Returns the flipped "rotation" block state string"""
     rotationInt = int(rotation)
-    if flip.x:
+    if flip[0]:
         rotationInt = (16 - rotationInt) % 16
-    if flip.z:
+    if flip[2]:
         rotationInt = (8 - rotationInt) % 16
     return str(rotationInt)
 
 
-def transformRotation(blockStateRotation: str, rotation: int = 0, flip: bvec3 = bvec3()):
+def transformRotation(blockStateRotation: str, rotation: int = 0, flip: Vec3bLike = bvec3()):
     """Returns the transformed "rotation" block state string.\n
     Flips first, rotates second."""
     return rotateRotation(flipRotation(blockStateRotation, flip), rotation)

--- a/gdpc/geometry.py
+++ b/gdpc/geometry.py
@@ -3,14 +3,12 @@
 
 from typing import Optional, Union, List, Iterable
 
-from glm import ivec2, ivec3
-
-from .vector_tools import Rect, Box, cylinder, fittingCylinder, line3D, lineSequence3D
+from .vector_tools import Vec2iLike, Vec3iLike, Rect, Box, cylinder, fittingCylinder, line3D, lineSequence3D
 from .block import Block
 from .editor import Editor
 
 
-def placeCuboid(editor: Editor, first: ivec3, last: ivec3, block: Block, replace: Optional[Union[str, List[str]]] = None):
+def placeCuboid(editor: Editor, first: Vec3iLike, last: Vec3iLike, block: Block, replace: Optional[Union[str, List[str]]] = None):
     """Places a box of [block] blocks from [first] to [last] (inclusive)."""
     # Transform only the key points instead of all points
     first = editor.transform * first
@@ -19,7 +17,7 @@ def placeCuboid(editor: Editor, first: ivec3, last: ivec3, block: Block, replace
     editor.placeBlockGlobal(Box.between(first, last).inner, block, replace)
 
 
-def placeCuboidHollow(editor: Editor, first: ivec3, last: ivec3, block: Block, replace: Optional[Union[str, List[str]]] = None):
+def placeCuboidHollow(editor: Editor, first: Vec3iLike, last: Vec3iLike, block: Block, replace: Optional[Union[str, List[str]]] = None):
     """Places a hollow box of [block] blocks from [first] to [last] (inclusive)."""
     # Transform only the key points instead of all points
     first = editor.transform * first
@@ -28,7 +26,7 @@ def placeCuboidHollow(editor: Editor, first: ivec3, last: ivec3, block: Block, r
     editor.placeBlockGlobal(Box.between(first, last).shell, block, replace)
 
 
-def placeCuboidWireframe(editor: Editor, first: ivec3, last: ivec3, block: Block, replace: Optional[Union[str, List[str]]] = None):
+def placeCuboidWireframe(editor: Editor, first: Vec3iLike, last: Vec3iLike, block: Block, replace: Optional[Union[str, List[str]]] = None):
     """Places a wireframe of [block] blocks from [first] to [last] (inclusive)."""
     # Transform only the key points instead of all points
     first = editor.transform * first
@@ -65,7 +63,7 @@ def placeRectOutline(editor: Editor, rect: Rect, y: int, block: Block, replace: 
     placeBoxWireframe(editor, rect.toBox(y, 1), block, replace)
 
 
-def placeCheckeredCuboid(editor: Editor, first: ivec3, last: ivec3, block1: Block, block2: Block = Block(""), replace: Optional[Union[str, List[str]]] = None):
+def placeCheckeredCuboid(editor: Editor, first: Vec3iLike, last: Vec3iLike, block1: Block, block2: Block = Block(""), replace: Optional[Union[str, List[str]]] = None):
     """Places a checker pattern of [block1] and [block2] in the box between [first] and [last] (inclusive)"""
     placeCheckeredBox(editor, Box.between(first, last), block1, block2, replace)
 
@@ -77,7 +75,7 @@ def placeCheckeredBox(editor: Editor, box: Box, block1: Block, block2: Block = B
         editor.placeBlock(box.offset + pos, block1 if sum(pos) % 2 == 0 else block2, replace)
 
 
-def placeStripedCuboid(editor: Editor, first: ivec3, last: ivec3, stripeAxis: int, block1: Block, block2: Block = Block(""), replace: Optional[Union[str, List[str]]] = None):
+def placeStripedCuboid(editor: Editor, first: Vec3iLike, last: Vec3iLike, stripeAxis: int, block1: Block, block2: Block = Block(""), replace: Optional[Union[str, List[str]]] = None):
     """Places a stripe pattern of [block1] and [block2] along [stripeAxis] (0, 1 or 2) in the box
     between [first] and [last] (inclusive)"""
     placeStripedBox(editor, Box.between(first, last), stripeAxis, block1, block2, replace)
@@ -90,7 +88,7 @@ def placeStripedBox(editor: Editor, box: Box, stripeAxis: int, block1: Block, bl
         editor.placeBlock(box.offset + pos, block1 if pos[stripeAxis] % 2 == 0 else block2, replace)
 
 
-def placeLine(editor: Editor, first: ivec3, last: ivec3, block: Block, width=1, replace: Optional[Union[str, List[str]]] = None):
+def placeLine(editor: Editor, first: Vec3iLike, last: Vec3iLike, block: Block, width=1, replace: Optional[Union[str, List[str]]] = None):
     """Places a line of [block] blocks from [first] to [last] (inclusive).\n
     When placing axis-aligned lines, placeCuboid and placeBox are more efficient."""
     # Transform only the key points instead of all points
@@ -100,14 +98,14 @@ def placeLine(editor: Editor, first: ivec3, last: ivec3, block: Block, width=1, 
     editor.placeBlockGlobal(line3D(first, last, width), block, replace)
 
 
-def placeLineSequence(editor: Editor, points: Iterable[ivec3], block: Block, closed=False, replace: Optional[Union[str, List[str]]] = None):
+def placeLineSequence(editor: Editor, points: Iterable[Vec3iLike], block: Block, closed=False, replace: Optional[Union[str, List[str]]] = None):
     """Place lines that run from point to point."""
     editor.placeBlock(lineSequence3D(points, closed=closed), block, replace)
 
 
 def placeCylinder(
     editor: Editor,
-    baseCenter: ivec3, diameters: Union[ivec2, int], length: int,
+    baseCenter: Vec3iLike, diameters: Union[Vec2iLike, int], length: int,
     block: Block,
     axis=1, tube=False, hollow=False,
     replace: Optional[Union[str, List[str]]] = None
@@ -118,7 +116,7 @@ def placeCylinder(
 
 def placeFittingCylinder(
     editor: Editor,
-    corner1: ivec3, corner2: ivec3,
+    corner1: Vec3iLike, corner2: Vec3iLike,
     block: Block,
     axis=1, tube=False, hollow=False,
     replace: Optional[Union[str, List[str]]] = None

--- a/gdpc/minecraft_tools.py
+++ b/gdpc/minecraft_tools.py
@@ -4,9 +4,7 @@
 from typing import Any, Optional, Union, List
 from functools import lru_cache
 
-from glm import ivec2
-
-from .vector_tools import Rect
+from .vector_tools import Vec2iLike, Rect
 from . import lookup
 from .block import Block
 
@@ -220,11 +218,11 @@ def lecternBlock(facing: str = "north", bookData: Optional[str] = None, page: in
 # ==================================================================================================
 
 
-def positionToInventoryIndex(position: ivec2, inventorySize: ivec2):
+def positionToInventoryIndex(position: Vec2iLike, inventorySize: Vec2iLike):
     """Returns the flat index of the slot at <position> in an inventory of size <inventorySize>."""
     if not Rect(size=inventorySize).contains(position):
         raise ValueError(f"{position} is not between (0, 0) and {inventorySize}!")
-    return position.x + position.y * inventorySize.x
+    return position[0] + position[1] * inventorySize[0]
 
 
 def getObtrusiveness(block: Block):

--- a/gdpc/model.py
+++ b/gdpc/model.py
@@ -5,7 +5,7 @@ from typing import Union, Optional, List, Dict
 from copy import copy
 from glm import ivec3
 
-from .vector_tools import Box
+from .vector_tools import Vec3iLike, Box
 from .transform import TransformLike
 from .editor import Editor
 from .block import Block
@@ -18,15 +18,16 @@ class Model:
     transformations.
     """
 
-    def __init__(self, size: ivec3, blocks: Optional[List[Optional[Block]]] = None):
+    def __init__(self, size: Vec3iLike, blocks: Optional[List[Optional[Block]]] = None):
         """Constructs a Model of size [size], optionally filled with [blocks]."""
-        self._size = copy(size)
+        self._size = ivec3(*size)
         if blocks is not None:
-            if len(blocks) != size.x * size.y * size.z:
-                raise ValueError("The number of blocks should be equal to size.x * size.y * size.z")
+            volume = self._size.x * self._size.y * self._size.z
+            if len(blocks) != volume:
+                raise ValueError("The number of blocks should be equal to size[0] * size[1] * size[2]")
             self._blocks = copy(blocks)
         else:
-            self._blocks = [None] * (size.x * size.y * size.z)
+            self._blocks = [None] * volume
 
 
     @property
@@ -40,13 +41,13 @@ class Model:
         return copy(self._blocks) # Allows block modification, but not resizing
 
 
-    def getBlock(self, position: ivec3):
+    def getBlock(self, position: Vec3iLike):
         """Returns the block at [vec]"""
-        return self._blocks[(position.x * self._size.y + position.y) * self._size.z + position.z]
+        return self._blocks[(position[0] * self._size.y + position[1]) * self._size.z + position[2]]
 
-    def setBlock(self, position: ivec3, block: Optional[Block]):
+    def setBlock(self, position: Vec3iLike, block: Optional[Block]):
         """Sets the block at [vec] to [block]"""
-        self._blocks[(position.x * self._size.y + position.y) * self._size.z + position.z] = block
+        self._blocks[(position[0] * self._size.y + position[1]) * self._size.z + position[2]] = block
 
 
     def build(


### PR DESCRIPTION
Rewrote all functions that take a pyGLM vector as a parameter (i.e. pretty much all of them) to accept a generic VecLike instead.

The requirements on the VecLike types (`Vec2iLike`, `Vec3bLike`, etc.) are very minimal. In particular, both integer tuples and pyGLM vectors are valid VecNiLike-s.

This change allows developers to use GDPC with any vector system, and it allows them to perform simple API calls without needing to instantiatiate objects from a third party library (pyGLM).
For example: `editor.placeBlock((1,2,3), Block("stone"))` vs `editor.placeBlock(ivec3(1,2,3), Block("stone"))`.

This change unfortunately makes GDPC itself more complicated to develop and read. Contributors may wonder what the difference between `ivec2` and `Vec2iLike` is, for example. It also comes at a small performance cost, though the performance cost appears to be negligible compared to the time spent waiting on requests.

In the end, the trade-off is *ease of using GDPC* versus *ease of developing GDPC*. This change improves the former but worsens the latter. I find the trade-off worth it in this case.