### PR TITLE
Fix in-buffer block overwrites not going to the end of the buffer

### DIFF
--- a/gdpc/editor.py
+++ b/gdpc/editor.py
@@ -478,6 +478,7 @@ class Editor:
         Returns whether placement succeeded."""
         if len(self._buffer) >= self.bufferLimit:
             self.flushBuffer()
+        self._buffer.pop(position, None) # Ensure the new block is added at the *end* of the buffer.
         self._buffer[position] = block
         return True
 


### PR DESCRIPTION
Previously, in-buffer block overwrites would put the new block at the same place in the buffer order as the old block, which could lead to incorrect behavior.

Fixes #77.