### PR TITLE
Place and get structure endpoint

### DIFF
--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -242,12 +242,15 @@ def placeStructure(structureBytes, position: Vec3iLike, mirror: Optional[Vec2iLi
     """
     url = f"{host}/structure"
     x, y, z = position
+    rotate = (rotate % 4) if rotate else None
     mirrorArg = None
-    if mirror[0]:
+    if mirror[0] and mirror[1]:
+        mirrorArg = 'z'
+        rotate = 1
+    elif mirror[0]:
         mirrorArg = 'x'
     elif mirror[1]:
         mirrorArg = 'z'
-    rotate = (rotate % 4) if rotate else None
     pivotX, pivotY, pivotZ = (None, None, None) if pivot is None else pivot
     parameters = {
         'x': x,

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -242,7 +242,7 @@ def placeStructure(structureFile, position: Vec3iLike, mirror: Optional[str] = N
     url = f"{host}/structure"
     x, y, z = position
     mirror = mirror if mirror == 'x' or mirror == 'z' else None
-    rotate = (rotate % 4) if isinstance(rotate, int) else None
+    rotate = (rotate % 4) if rotate else None
     pivotX, pivotY, pivotZ = (None, None, None) if pivot is None else pivot
     parameters = {
         'x': x,

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -230,7 +230,7 @@ def getChunks(position: Vec2iLike, size: Optional[Vec2iLike] = None, dimension: 
     return response.content if asBytes else response.text
 
 
-def placeStructure(structureFile, position: ivec3, mirror: Optional[str] = None, rotate: Optional[int] = None, pivot: Optional[Vec3iLike] = None, includeEntities: Optional[bool] = None, dimension: Optional[str] = None, doBlockUpdates=True, spawnDrops=False, customFlags: str = "", retries=0, timeout=None, host=DEFAULT_HOST):
+def placeStructure(structureFile, position: Vec3iLike, mirror: Optional[str] = None, rotate: Optional[int] = None, pivot: Optional[Vec3iLike] = None, includeEntities: Optional[bool] = None, dimension: Optional[str] = None, doBlockUpdates=True, spawnDrops=False, customFlags: str = "", retries=0, timeout=None, host=DEFAULT_HOST):
     """Places an NBT structure file into the world.
 
     <structureFile> a string of bytes derived from an .nbt file. These files can be generated in various ways, such

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -245,8 +245,7 @@ def placeStructure(structureBytes, position: Vec3iLike, mirror: Optional[Vec2iLi
     rotate = (rotate % 4) if rotate else None
     mirrorArg = None
     if mirror[0] and mirror[1]:
-        mirrorArg = 'z'
-        rotate = 1
+        rotate = (rotate + 2) % 4
     elif mirror[0]:
         mirrorArg = 'x'
     elif mirror[1]:

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -266,7 +266,7 @@ def placeStructure(structureFile, position: Vec3iLike, mirror: Optional[str] = N
     return response.json()
 
 
-def getStructure(position: Vec3iLike, size: Vec3iLike, dimension: Optional[str] = None, includeEntities: Optional[bool] = None, retries=0, timeout=None, host=DEFAULT_HOST):
+def getStructure(position: Vec3iLike, size: Vec3iLike, dimension: Optional[str] = None, includeEntities: Optional[bool] = None, returnCompressed: Optional[bool] = True, retries=0, timeout=None, host=DEFAULT_HOST):
     """Generate NBT structure file from an area in the world.
 
     Returns a string of bytes which can be saved into an .nbt file which can be placed using tools such as the
@@ -290,8 +290,9 @@ def getStructure(position: Vec3iLike, size: Vec3iLike, dimension: Optional[str] 
         'dimension': dimension,
         'entities': includeEntities,
     }
+    headers = {'Accept-Encoding': 'gzip'} if returnCompressed is True else None
 
-    response = _request(method="GET", url=url, params=parameters, retries=retries, timeout=timeout)
+    response = _request(method="GET", url=url, params=parameters, headers=headers, retries=retries, timeout=timeout)
     return response.content
 
 

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -230,6 +230,36 @@ def getChunks(position: Vec2iLike, size: Optional[Vec2iLike] = None, dimension: 
     return response.content if asBytes else response.text
 
 
+def placeStructure(structureFile, position: ivec3, mirror: Optional[str] = None, rotate: Optional[int] = None, pivot: Optional[Vec3iLike] = None, includeEntities: Optional[bool] = None, dimension: Optional[str] = None, doBlockUpdates=True, spawnDrops=False, customFlags: str = "", retries=0, timeout=None, host=DEFAULT_HOST):
+    """Places an NBT structure file into the world.
+    """
+    url = f"{host}/structure"
+    x, y, z = position
+    mirror = mirror if mirror == 'x' or mirror == 'z' else None
+    rotate = (rotate % 4) if isinstance(rotate, int) else None
+    pivotX, pivotY, pivotZ = (None, None, None) if pivot is None else pivot
+    parameters = {
+        'x': x,
+        'y': y,
+        'z': z,
+        'mirror': mirror,
+        'rotate': rotate,
+        'pivotx': pivotX,
+        'pivoty': pivotY,
+        'pivotz': pivotZ,
+        'dimension': dimension,
+        'entities': includeEntities,
+    }
+    if customFlags != "":
+        parameters['customFlags'] = customFlags
+    else:
+        parameters['doBlockUpdates'] = doBlockUpdates
+        parameters['spawnDrops'] = spawnDrops
+
+    response = _request(method="POST", url=url, data=structureFile, params=parameters, retries=retries, timeout=timeout)
+    return response.json()
+
+
 def getVersion(retries=0, timeout=None, host=DEFAULT_HOST):
     """Returns the Minecraft version as a string."""
     return _request("GET", f"{host}/version", retries=retries, timeout=timeout).text

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -266,6 +266,35 @@ def placeStructure(structureFile, position: ivec3, mirror: Optional[str] = None,
     return response.json()
 
 
+def getStructure(position: Vec3iLike, size: Vec3iLike, dimension: Optional[str] = None, includeEntities: Optional[bool] = None, retries=0, timeout=None, host=DEFAULT_HOST):
+    """Generate NBT structure file from an area in the world.
+
+    Returns a string of bytes which can be saved into an .nbt file which can be placed using tools such as the
+    POST /structure endpoint in GDMC-HTTP or the in-game minecraft:structure_block.
+
+    Setting the <includeEntities> to True will attach all entities present in the given area at the moment of calling
+    getStructure to the resulting file. Meaning that saving a house in a Minecraft village will include the NPC
+    living inside it. Note that when placing this structure using GDMC-HTTP, the includeEntities parameter needs to
+    be set to True for these entities to be placed into the world together with the blocks making up the structure.
+    """
+    url = f"{host}/structure"
+    x, y, z = position
+    dx, dy, dz = size
+    parameters = {
+        'x': x,
+        'y': y,
+        'z': z,
+        'dx': dx,
+        'dy': dy,
+        'dz': dz,
+        'dimension': dimension,
+        'entities': includeEntities,
+    }
+
+    response = _request(method="GET", url=url, params=parameters, retries=retries, timeout=timeout)
+    return response.content
+
+
 def getVersion(retries=0, timeout=None, host=DEFAULT_HOST):
     """Returns the Minecraft version as a string."""
     return _request("GET", f"{host}/version", retries=retries, timeout=timeout).text

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -232,6 +232,12 @@ def getChunks(position: Vec2iLike, size: Optional[Vec2iLike] = None, dimension: 
 
 def placeStructure(structureFile, position: ivec3, mirror: Optional[str] = None, rotate: Optional[int] = None, pivot: Optional[Vec3iLike] = None, includeEntities: Optional[bool] = None, dimension: Optional[str] = None, doBlockUpdates=True, spawnDrops=False, customFlags: str = "", retries=0, timeout=None, host=DEFAULT_HOST):
     """Places an NBT structure file into the world.
+
+    <structureFile> a string of bytes derived from an .nbt file. These files can be generated in various ways, such
+    as using the in-game minecraft:structure_block or the GET /structure endpoint in GDMC-HTTP.
+
+    This endpoint has a large number of parameters, where only <structureFile> and <position> are required.
+    See the GDMC HTTP API documentation for more information about these parameters.
     """
     url = f"{host}/structure"
     x, y, z = position

--- a/gdpc/nbt_tools.py
+++ b/gdpc/nbt_tools.py
@@ -1,4 +1,5 @@
 """Utilities for working with Minecraft's NBT and SNBT formats"""
+from typing import Union
 from pathlib import Path
 from nbt import nbt
 
@@ -32,55 +33,28 @@ def nbtToSnbt(tag: nbt.TAG) -> str:
     raise TypeError(f"Unrecognized tag type: {type(tag)}")
 
 
-def openNBTFile(
-    filePath: Path | str = None
-):
-    """Opens stored NBT file and returns it as a file object."""
-    if isinstance(filePath, str):
-        filePath = Path(filePath)
-
-    if not filePath.name.endswith('.nbt'):
-        filePath = filePath.with_suffix('.nbt')
-
-    return open(filePath, 'rb')
-
-
-def createByteStringFromNBTFile(
-    filePath: Path | str = None
-):
-    """Get string of bytes derived from stored NBT file."""
-    fileObject = openNBTFile(filePath)
-    rawBytes = fileObject.read()
-    fileObject.close()
-    return rawBytes
-
-
-def createNBTObjectFromNBTFile(
-    filePath: Path | str = None
+def parseNbtFile(
+    filePath: Union[Path, str]
 ):
     """Create NBT object from stored NBT file."""
-    fileObject = openNBTFile(filePath)
+    if isinstance(filePath, str):
+        filePath = Path(filePath)
+    fileObject = open(filePath, 'rb')
     return nbt.NBTFile(fileobj=fileObject)
 
 
-def saveNBTFile(
-    filePath: Path | str = None,
-    fileContent: bytes | nbt.NBTFile = b''
+def saveNbtTFile(
+    filePath: Union[Path, str],
+    data: Union[bytes, nbt.NBTFile]
 ):
+    """Save string of bytes or NBTFile object to a file."""
     if isinstance(filePath, str):
         filePath = Path(filePath)
-    elif filePath is None or not isinstance(filePath, Path):
-        raise TypeError(f"Not a valid path: {filePath}")
-    if not filePath.parent.exists():
-        raise FileNotFoundError(f"Save location does not exist: {filePath.parent}")
-
-    if not filePath.name.endswith('.nbt'):
-        filePath = filePath.with_suffix('.nbt')
 
     with open(filePath, 'wb') as file:
-        if isinstance(fileContent, bytes):
-            file.write(fileContent)
+        if isinstance(data, bytes):
+            file.write(data)
             file.close()
-        elif isinstance(fileContent, nbt.NBTFile):
-            fileContent.write_file(fileobj=file)
+        elif isinstance(data, nbt.NBTFile):
+            data.write_file(fileobj=file)
         print(f"File saved to: {filePath}")

--- a/gdpc/nbt_tools.py
+++ b/gdpc/nbt_tools.py
@@ -43,7 +43,7 @@ def parseNbtFile(
     return nbt.NBTFile(fileobj=fileObject)
 
 
-def saveNbtTFile(
+def saveNbtFile(
     filePath: Union[Path, str],
     data: Union[bytes, nbt.NBTFile]
 ):

--- a/gdpc/nbt_tools.py
+++ b/gdpc/nbt_tools.py
@@ -1,6 +1,5 @@
 """Utilities for working with Minecraft's NBT and SNBT formats"""
-
-
+from pathlib import Path
 from nbt import nbt
 
 
@@ -31,3 +30,57 @@ def nbtToSnbt(tag: nbt.TAG) -> str:
     if isinstance(tag, nbt.TAG_String):
         return repr(tag.value)
     raise TypeError(f"Unrecognized tag type: {type(tag)}")
+
+
+def openNBTFile(
+    filePath: Path | str = None
+):
+    """Opens stored NBT file and returns it as a file object."""
+    if isinstance(filePath, str):
+        filePath = Path(filePath)
+
+    if not filePath.name.endswith('.nbt'):
+        filePath = filePath.with_suffix('.nbt')
+
+    return open(filePath, 'rb')
+
+
+def createByteStringFromNBTFile(
+    filePath: Path | str = None
+):
+    """Get string of bytes derived from stored NBT file."""
+    fileObject = openNBTFile(filePath)
+    rawBytes = fileObject.read()
+    fileObject.close()
+    return rawBytes
+
+
+def createNBTObjectFromNBTFile(
+    filePath: Path | str = None
+):
+    """Create NBT object from stored NBT file."""
+    fileObject = openNBTFile(filePath)
+    return nbt.NBTFile(fileobj=fileObject)
+
+
+def saveNBTFile(
+    filePath: Path | str = None,
+    fileContent: bytes | nbt.NBTFile = b''
+):
+    if isinstance(filePath, str):
+        filePath = Path(filePath)
+    elif filePath is None or not isinstance(filePath, Path):
+        raise TypeError(f"Not a valid path: {filePath}")
+    if not filePath.parent.exists():
+        raise FileNotFoundError(f"Save location does not exist: {filePath.parent}")
+
+    if not filePath.name.endswith('.nbt'):
+        filePath = filePath.with_suffix('.nbt')
+
+    with open(filePath, 'wb') as file:
+        if isinstance(fileContent, bytes):
+            file.write(fileContent)
+            file.close()
+        elif isinstance(fileContent, nbt.NBTFile):
+            fileContent.write_file(fileobj=file)
+        print(f"File saved to: {filePath}")

--- a/gdpc/utils.py
+++ b/gdpc/utils.py
@@ -1,9 +1,8 @@
 """Various utilities that are not specific to GDPC"""
 
-
-from typing import TypeVar, Generic, Callable, Iterable, OrderedDict
+from typing import TypeVar, Generic, Callable, Iterable, OrderedDict, Union
 import time
-import sys
+from pathlib import Path
 
 import numpy as np
 import cv2
@@ -144,3 +143,15 @@ def visualizeMaps(*arrays, title="", normalize=True):
         plt_image = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
         plt.imshow(plt_image)
     plt.show()
+
+
+def readFileBytes(
+    filePath: Union[Path, str]
+) -> bytes:
+    """Opens stored file and returns it a string of bytes."""
+    if isinstance(filePath, str):
+        filePath = Path(filePath)
+    fileObject = open(filePath, 'rb')
+    rawBytes = fileObject.read()
+    fileObject.close()
+    return rawBytes


### PR DESCRIPTION
Implements interfaces for the [`POST /structure`](https://github.com/Niels-NTG/gdmc_http_interface/blob/master/docs/Endpoints.md#place-nbt-structure-file-post-structure) and [`GET /structure`](https://github.com/Niels-NTG/gdmc_http_interface/blob/master/docs/Endpoints.md#create-nbt-structure-file-get-structure) endpoints present in GDMC-HTTP.

This doesn't currently include any integration with the `Editor` class or an util method that help with loading and saving `*.nbt` files. I would want to include these as well but don't know where best to put these.