### PR TITLE
Add hash method to Rect and Box to enable caching

### DIFF
--- a/gdpc/vector_tools.py
+++ b/gdpc/vector_tools.py
@@ -331,6 +331,9 @@ class Rect:
         self._offset = ivec2(*offset)
         self._size   = ivec2(*size)
 
+    def __hash__(self):
+        return hash((self.offset, self.size))
+
     def __repr__(self):
         return f"Rect({tuple(self._offset)}, {tuple(self._size)})"
 
@@ -508,6 +511,9 @@ class Box:
     def __init__(self, offset: Vec3iLike = (0,0,0), size: Vec3iLike = (0,0,0)):
         self._offset = ivec3(*offset)
         self._size   = ivec3(*size)
+
+    def __hash__(self):
+        return hash((self.offset, self.size))
 
     def __repr__(self):
         return f"Box({tuple(self._offset)}, {tuple(self._size)})"


### PR DESCRIPTION
I've implemented a `__hash__` to both `Rect` and `Box`. This allows the results of functions that use these types in their arguments to be cached when using [`@functools.cache`](https://docs.python.org/3/library/functools.html#functools.cache) annotation with the function.

Here is a (be it somewhat trivial) example:
```python
@functools.cache
def isRectinRect(rectA: Rect, rectB: Rect) -> bool:
    return (
        rectB.begin.x >= rectA.begin.x and
        rectB.begin.y >= rectA.begin.y and
        rectB.end.x <= rectA.end.x and
        rectB.end.y <= rectA.end.y
    )
```
By hashing `rectA` and `rectB` the result of this function can be cached for any combination of arguments, meaning that it can skip over re-calculating the results if the combination of arguments is already cached.