### PR TITLE
Fix #78

### DIFF
--- a/gdpc/vector_tools.py
+++ b/gdpc/vector_tools.py
@@ -23,7 +23,7 @@ from .utils import nonZeroSign
 class Vec2LikeMeta(_ProtocolMeta):
     """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains two items."""
     def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
-        return super().__instancecheck__(instance) and len(instance) == 3
+        return super().__instancecheck__(instance) and len(instance) == 2
 
 class Vec3LikeMeta(_ProtocolMeta):
     """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains three items."""

--- a/gdpc/vector_tools.py
+++ b/gdpc/vector_tools.py
@@ -1,8 +1,8 @@
 """Various vector utilities"""
 
 
-from typing import _ProtocolMeta, Iterator, Protocol, Any, Iterable, List, Optional, Set, Tuple, Union, runtime_checkable
-from abc import ABCMeta
+from typing import Iterator, Any, Iterable, List, Optional, Set, Tuple, Union
+from typing_extensions import Protocol
 from dataclasses import dataclass
 import math
 
@@ -20,39 +20,25 @@ from .utils import nonZeroSign
 # VecLike Protocols
 # ==================================================================================================
 
-class Vec2LikeMeta(_ProtocolMeta):
-    """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains two items."""
-    def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
-        return super().__instancecheck__(instance) and len(instance) == 2
-
-class Vec3LikeMeta(_ProtocolMeta):
-    """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains three items."""
-    def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
-        return super().__instancecheck__(instance) and len(instance) == 3
-
-@runtime_checkable
-class Vec2iLike(Protocol, metaclass=Vec2LikeMeta):
+class Vec2iLike(Protocol):
     """Protocol for a vector that contains two integers."""
     def __getitem__(self, __i: int) -> int: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
 
-@runtime_checkable
-class Vec3iLike(Protocol, metaclass=Vec3LikeMeta):
+class Vec3iLike(Protocol):
     """Protocol for a vector that contains three integers."""
     def __getitem__(self, __i: int) -> int: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
 
-@runtime_checkable
-class Vec2bLike(Protocol, metaclass=Vec2LikeMeta):
+class Vec2bLike(Protocol):
     """Protocol for a vector that contains two bools."""
     def __getitem__(self, __i: int) -> bool: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[bool]: ...
 
-@runtime_checkable
-class Vec3bLike(Protocol, metaclass=Vec3LikeMeta):
+class Vec3bLike(Protocol):
     """Protocol for a vector that contains three bools."""
     def __getitem__(self, __i: int) -> bool: ...
     def __len__(self) -> int: ...

--- a/gdpc/vector_tools.py
+++ b/gdpc/vector_tools.py
@@ -1,7 +1,7 @@
 """Various vector utilities"""
 
 
-from typing import _ProtocolMeta, Iterator, Protocol, Any, Iterable, List, Optional, Set, Tuple, Union
+from typing import _ProtocolMeta, Iterator, Protocol, Any, Iterable, List, Optional, Set, Tuple, Union, runtime_checkable
 from abc import ABCMeta
 from dataclasses import dataclass
 import math
@@ -30,24 +30,28 @@ class Vec3LikeMeta(_ProtocolMeta):
     def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
         return super().__instancecheck__(instance) and len(instance) == 3
 
+@runtime_checkable
 class Vec2iLike(Protocol, metaclass=Vec2LikeMeta):
     """Protocol for a vector that contains two integers."""
     def __getitem__(self, __i: int) -> int: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
 
+@runtime_checkable
 class Vec3iLike(Protocol, metaclass=Vec3LikeMeta):
     """Protocol for a vector that contains three integers."""
     def __getitem__(self, __i: int) -> int: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[int]: ...
 
+@runtime_checkable
 class Vec2bLike(Protocol, metaclass=Vec2LikeMeta):
     """Protocol for a vector that contains two bools."""
     def __getitem__(self, __i: int) -> bool: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[bool]: ...
 
+@runtime_checkable
 class Vec3bLike(Protocol, metaclass=Vec3LikeMeta):
     """Protocol for a vector that contains three bools."""
     def __getitem__(self, __i: int) -> bool: ...

--- a/gdpc/vector_tools.py
+++ b/gdpc/vector_tools.py
@@ -1,9 +1,8 @@
 """Various vector utilities"""
 
 
-from typing import Sequence, Any, Iterable, List, Optional, Set, Tuple, Union
-from abc import ABC
-from numbers import Integral
+from typing import _ProtocolMeta, Iterator, Protocol, Any, Iterable, List, Optional, Set, Tuple, Union
+from abc import ABCMeta
 from dataclasses import dataclass
 import math
 
@@ -18,45 +17,42 @@ from .utils import nonZeroSign
 
 
 # ==================================================================================================
-# VecLike ABCs
+# VecLike Protocols
 # ==================================================================================================
 
+class Vec2LikeMeta(_ProtocolMeta):
+    """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains two items."""
+    def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
+        return super().__instancecheck__(instance) and len(instance) == 3
 
-class Vec2iLike(ABC, Sequence[int]):
-    """An abstract base class. A class is a Vec2iLike if it acts like a sequence of two Integrals."""
-    @classmethod
-    def __subclasshook__(cls, C):
-        try:
-            return len(C) == 2 and all(isinstance(C[i], Integral) for i in range(2))
-        except TypeError:
-            return False
+class Vec3LikeMeta(_ProtocolMeta):
+    """Metaclass that hooks into the metaclass of the Protocol to check that the vector contains three items."""
+    def __instancecheck__(cls: ABCMeta, instance: Any) -> bool:
+        return super().__instancecheck__(instance) and len(instance) == 3
 
-class Vec3iLike(ABC, Sequence[int]):
-    """An abstract base class. A class is a Vec3iLike if it acts like a sequence of three Integrals."""
-    @classmethod
-    def __subclasshook__(cls, C):
-        try:
-            return len(C) == 3 and all(isinstance(C[i], Integral) for i in range(3))
-        except TypeError:
-            return False
+class Vec2iLike(Protocol, metaclass=Vec2LikeMeta):
+    """Protocol for a vector that contains two integers."""
+    def __getitem__(self, __i: int) -> int: ...
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator[int]: ...
 
-class Vec2bLike(ABC, Sequence[bool]):
-    """An abstract base class. A class is a Vec2bLike if it acts like a sequence of two bools."""
-    @classmethod
-    def __subclasshook__(cls, C):
-        try:
-            return len(C) == 2 and all(isinstance(C[i], bool) for i in range(2))
-        except TypeError:
-            return False
+class Vec3iLike(Protocol, metaclass=Vec3LikeMeta):
+    """Protocol for a vector that contains three integers."""
+    def __getitem__(self, __i: int) -> int: ...
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator[int]: ...
 
-class Vec3bLike(ABC, Sequence[bool]):
-    """An abstract base class. A class is a Vec3bLike if it acts like a sequence of three bools."""
-    @classmethod
-    def __subclasshook__(cls, C):
-        try:
-            return len(C) == 3 and all(isinstance(C[i], bool) for i in range(3))
-        except TypeError:
-            return False
+class Vec2bLike(Protocol, metaclass=Vec2LikeMeta):
+    """Protocol for a vector that contains two bools."""
+    def __getitem__(self, __i: int) -> bool: ...
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator[bool]: ...
+
+class Vec3bLike(Protocol, metaclass=Vec3LikeMeta):
+    """Protocol for a vector that contains three bools."""
+    def __getitem__(self, __i: int) -> bool: ...
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator[bool]: ...
 
 
 # ==================================================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.28.2
 scikit-image==0.19.3
 scipy==1.10.1
 termcolor==2.2.0
+typing_extensions==4.7.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         "requests",
         "scikit-image >= 0.19.0",
         "scipy",
-        "termcolor"
+        "termcolor",
+        "typing_extensions"
     ],
     python_requires=">=3.7, <4",
     classifiers=[


### PR DESCRIPTION
This fixes #78 by converting the ABCs to Protocols to support static type checkers like mypy and pyright. I also added two metaclasses to support checking if a object is Vec2Like or Vec3Like using `isinstance((0, 0, 0), Vec3iLike)`.