### PR TITLE
Change Fandom links to new Minecraft Wiki URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,14 +96,14 @@ general purpose. Most of these have been renamed, however:
 Lots of new modules have been added:
 - `block`: Provides the `Block` class, more on this later.
 - `block_state_tools`: Provides tools to work with orientation-related
-  [block states](https://minecraft.fandom.com/wiki/Block_states).
+  [block states](https://minecraft.wiki/wiki/Block_states).
   This is mainly for internal use.
 - `exceptions`: Contains exception classes for GDPC.
 - `model.py`: Provides the `Model` class, which can be used to store a structure
   in memory. Future versions will add features like scanning in models from
   Minecraft.
 - `nbt_tools`: Provides some low-level tools for the
-  [NBT format](https://minecraft.fandom.com/wiki/NBT_format). This is mainly for
+  [NBT format](https://minecraft.wiki/wiki/NBT_format). This is mainly for
   internal use.
 - `transform`: Provides the `Transform` class and related utilities, more on
   this later.
@@ -136,9 +136,9 @@ strings: you place and get `Block("stone")` instead of `"stone"`.
 
 Blocks consist of three components:
 - A (namespaced) id (e.g. `minecraft:chest`).
-- Optional [block states](https://minecraft.fandom.com/wiki/Block_states)
+- Optional [block states](https://minecraft.wiki/wiki/Block_states)
   (e.g. `facing=north`).
-- Optional [block entity](https://minecraft.fandom.com/wiki/Block_entity)
+- Optional [block entity](https://minecraft.wiki/wiki/Block_entity)
   (S)NBT data (e.g. `{Items: [{Slot: 13b, id: "apple", Count: 1b}]}`).
 
 The `Block` class supports all three of these. In other words, GDPC now fully

--- a/examples/emerald_city.py
+++ b/examples/emerald_city.py
@@ -83,7 +83,7 @@ LASTX, LASTY, LASTZ = BUILD_AREA.last
 # Using the start and end coordinates we are generating a world slice
 # It contains all manner of information, including heightmaps and biomes
 # For further information on what information it contains, see
-# https://minecraft.fandom.com/wiki/Chunk_format
+# https://minecraft.wiki/wiki/Chunk_format
 #
 # IMPORTANT: Keep in mind that a wold slice is a 'snapshot' of the world,
 # and any changes you make later on will not be reflected in the world slice

--- a/examples/tutorials/4_world_slice.py
+++ b/examples/tutorials/4_world_slice.py
@@ -47,7 +47,7 @@ except BuildAreaNotSetError:
 #
 # A world slice contains all kinds of information about a slice of the world, like blocks, biomes
 # and heightmaps. All of its data is extracted directly from Minecraft's chunk format:
-# https://minecraft.fandom.com/wiki/Chunk_format. World slices take a while to load, but accessing
+# https://minecraft.wiki/wiki/Chunk_format. World slices take a while to load, but accessing
 # data from them is very fast.
 #
 # To get a world slice, you need to specify a rectangular XZ-area using a Rect object (the 2D

--- a/examples/tutorials/6_advanced_blocks.py
+++ b/examples/tutorials/6_advanced_blocks.py
@@ -78,7 +78,7 @@ placeBox(editor, platformRect.toBox(101, 10), Block("air")) # Clear some space
 #   in one of six possible directions (north, south, east, west, up, down). GDPC uses the term
 #   "block states". Note, however, that the combination (block id, block states) is sometimes also
 #   called a "BlockState". Yes, the terminology is confusing.
-#   A full list of all block states can be found at https://minecraft.fandom.com/wiki/Block_states.
+#   A full list of all block states can be found at https://minecraft.wiki/wiki/Block_states.
 #
 # - Its *block entity data*. A few blocks have particularly complex data attached to them, such as
 #   the items in a chest or the text on a sign. Minecraft stores this kind of data in a so-called
@@ -86,9 +86,9 @@ placeBox(editor, platformRect.toBox(101, 10), Block("air")) # Clear some space
 #   Binary Tag), a binary data structure. NBT also has a human-readable text representation called
 #   SNBT (Stringified NBT). The GDMC HTTP Interface and GDPC both use this SNBT format.
 #   A full list of all blocks with block entities can be found at
-#   https://minecraft.fandom.com/wiki/Block_entity.
+#   https://minecraft.wiki/wiki/Block_entity.
 #   For more information about the NBT and SNBT formats, see
-#   https://minecraft.fandom.com/wiki/NBT_format.
+#   https://minecraft.wiki/wiki/NBT_format.
 
 
 # GDPC's Block class represents a Minecraft block, consisting of a block id, optional block states

--- a/gdpc/editor.py
+++ b/gdpc/editor.py
@@ -281,7 +281,7 @@ class Editor:
         reflected in the command's execution context! This means that the use of local coordinate
         offsets (e.g. "^1 ^2 ^3") is in general not safe.
         For more details about relative and local command coordinates, see
-        https://minecraft.fandom.com/wiki/Coordinates#Commands"""
+        https://minecraft.wiki/wiki/Coordinates#Commands"""
         if position is not None:
             position = self.transform * position
         self.runCommandGlobal(command, position, syncWithBuffer)
@@ -297,7 +297,7 @@ class Editor:
         This means that, for example, the position "~ ~ ~" in the command will correspond to
         <position>.
         For more details about relative and local command coordinates, see
-        https://minecraft.fandom.com/wiki/Coordinates#Commands"""
+        https://minecraft.wiki/wiki/Coordinates#Commands"""
         if position is not None:
             command = f"execute positioned {' '.join(str(c) for c in position)} run {command}"
 

--- a/gdpc/lookup.py
+++ b/gdpc/lookup.py
@@ -3,7 +3,7 @@
 NOTE: The block id categories here may not be fully up-to-date with the latest supported Minecraft
 version. Although the block categories are not officially deprecated, there is a high chance that
 they will be in the future. They will most likely be replaced with categories automatically
-constructed from Minecraft's block tags (https://minecraft.fandom.com/wiki/Tag#Block_tags), because
+constructed from Minecraft's block tags (https://minecraft.wiki/wiki/Tag#Block_tags), because
 this is more standardized and way easier to keep up-to-date.
 
 To get a complete listing of all blocks for any Minecraft version, including various properties,
@@ -73,8 +73,8 @@ def variate(
 
 
 # COLOURS
-# based on https://minecraft.fandom.com/wiki/Dye#Color_values
-#   and https://minecraft.fandom.com/wiki/Block_colors
+# based on https://minecraft.wiki/wiki/Dye#Color_values
+#   and https://minecraft.wiki/wiki/Block_colors
 DYE_COLORS = {
     "white":      "0xF9FFFE",
     "orange":     "0xF9801D",

--- a/gdpc/minecraft_tools.py
+++ b/gdpc/minecraft_tools.py
@@ -91,7 +91,7 @@ def bookData(
     - `\\r`: When at start of line, align text to right side
 
     NOTE: For supported special characters see
-    https://minecraft.fandom.com/wiki/Language#Font
+    https://minecraft.wiki/wiki/Language#Font
     """
     pages_left      = lookup.BOOK_PAGES_PER_BOOK
     characters_left = lookup.BOOK_CHARACTERS_PER_PAGE

--- a/gdpc/world_slice.py
+++ b/gdpc/world_slice.py
@@ -15,7 +15,7 @@ from . import interface
 
 
 # Chunk format information:
-# https://minecraft.fandom.com/wiki/Chunk_format
+# https://minecraft.wiki/wiki/Chunk_format
 
 
 class _BitArray:


### PR DESCRIPTION
The wiki community has moved from the Fandom site to http://minecraft.wiki, so the old wiki is no longer maintained. Changing the links accordingly is better, to ensure up-to-date documentation. Also the new website is not inundated with advertisements.