### PR TITLE
Implement interface method for GET /entities + GET /players endpoints

### DIFF
--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -319,6 +319,17 @@ def getStructure(position: Vec3iLike, size: Vec3iLike, dimension: Optional[str] 
     return response.content
 
 
+def getEntities(selector: str = None, includeData: Optional[bool] = False, dimension: Optional[str] = None, retries=0, timeout=None, host=DEFAULT_HOST):
+    url = f'{host}/entities'
+    parameters = {
+        'selector': selector,
+        'dimension': dimension,
+        'includeData': includeData,
+    }
+    response = _request(method='GET', url=url, params=parameters, retries=retries, timeout=timeout)
+    return response.json()
+
+
 def getVersion(retries=0, timeout=None, host=DEFAULT_HOST):
     """Returns the Minecraft version as a string."""
     return _request("GET", f"{host}/version", retries=retries, timeout=timeout).text

--- a/gdpc/interface.py
+++ b/gdpc/interface.py
@@ -330,6 +330,17 @@ def getEntities(selector: str = None, includeData: Optional[bool] = False, dimen
     return response.json()
 
 
+def getPlayers(selector: str = None, includeData: Optional[bool] = False, dimension: Optional[str] = None, retries=0, timeout=None, host=DEFAULT_HOST):
+    url = f'{host}/players'
+    parameters = {
+        'selector': selector,
+        'dimension': dimension,
+        'includeData': includeData,
+    }
+    response = _request(method='GET', url=url, params=parameters, retries=retries, timeout=timeout)
+    return response.json()
+
+
 def getVersion(retries=0, timeout=None, host=DEFAULT_HOST):
     """Returns the Minecraft version as a string."""
     return _request("GET", f"{host}/version", retries=retries, timeout=timeout).text


### PR DESCRIPTION
Adds interface for `GET /entities` and `GET /players` endpoints, as requested by #100

I had `GET /entities` endpoint already in my personal fork of gdpc since last year but I forgot to contribute it to the main project until now.