### PR TITLE
Update book util to use format for Minecraft 1.21.4

### DIFF
--- a/src/gdpc/minecraft_tools.py
+++ b/src/gdpc/minecraft_tools.py
@@ -171,7 +171,7 @@ def lecternData(bookData: Optional[str], page: int = 0) -> str:
     See also: :func:`.lecternBlock`, :func:`.editor_tools.placeLectern`."""
     if bookData is None:
         return ""
-    return f'{{Book: {{id: "minecraft:written_book", Count: 1b, tag: {bookData}, Page: {page}}}}}'
+    return f'{{Book: {{id: "minecraft:written_book", Count: 1b, components: {bookData}, Page: {page}}}}}'
 
 
 def bookData(
@@ -179,7 +179,8 @@ def bookData(
     title       = "Chronicle",
     author      = "Anonymous",
     description = "I wonder what's inside?",
-    desccolor   = "gold"
+    desccolor   = "gold",
+    descIsItalic = True
 ) -> str:
     r"""Returns an SNBT string with written book data
 
@@ -316,13 +317,16 @@ def bookData(
         newpage()               # finish page
     del outputPages[-1] # end last page (book is complete)
 
-    loreJSON = json.dumps([{"text": description, "color": desccolor}])
+    loreJSON = json.dumps({"text": description, "color": desccolor, "italic": descIsItalic})
     pageJSON = [json.dumps({"text": p}) for p in outputPages]
     return (
         "{"
-        f'title: {repr(title)}, author: {repr(author)}, '
-        f'display:{{Lore:[{repr(loreJSON)}]}}, '
-        f'pages: [{",".join(repr(p) for p in pageJSON)}]'
+            "\"minecraft:written_book_content\": {"
+                f'title: {repr(title)}, '
+                f'author: {repr(author)}, '
+                f'pages: [{",".join(repr(p) for p in pageJSON)}]'
+            "},"
+            f'"lore": [{repr(loreJSON)}]'
         "}"
     )
 


### PR DESCRIPTION
Updates the `bookData` function in `minecraft_tools.py` such that it makes use of the [written book format](https://minecraft.wiki/w/Written_Book#Item_data) and the [lore format](https://minecraft.wiki/w/Data_component_format#lore) which are used by Minecraft 1.21.4.

Outside of the scope of this PR, I think that this function as a whole needs a rewrite, since the way it calculates when to insert a page break is *off*. We can look at other tools people have made to generate Minecraft book data, such as https://github.com/TheWilley/Text2Book, for inspiration.